### PR TITLE
Ordine provincie in Puglia

### DIFF
--- a/italia.json
+++ b/italia.json
@@ -64,7 +64,7 @@
 		{
 			"nome": "Puglia",
 			"capoluoghi": ["Bari", "Barletta-Andria-Trani", "Brindisi", "Lecce", "Foggia", "Taranto"],
-			"province":["BA","BT","BR","FG","LE","TA"]
+			"province":["BA","BT","BR","LE","FG","TA"]
 		},
 		{
 			"nome": "Sardegna",


### PR DESCRIPTION
Si scambiano d'ordine i capoluoghi Lecce e Foggia.