### PR TITLE
Lecce and Foggia names are swapped inside municipalities list

### DIFF
--- a/italia_comuni.json
+++ b/italia_comuni.json
@@ -29629,7 +29629,7 @@
                             "nome": "Zapponeta"
                         }
                     ], 
-                    "nome": "Lecce"
+                    "nome": "Foggia"
                 }, 
                 {
                     "code": "LE", 
@@ -30120,7 +30120,7 @@
                             "nome": "Zollino"
                         }
                     ], 
-                    "nome": "Foggia"
+                    "nome": "Lecce"
                 }, 
                 {
                     "code": "TA", 


### PR DESCRIPTION
code and name values for Foggia and Lecce don't match.
